### PR TITLE
ci: establish backend, frontend, and dependency gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,17 +89,46 @@ jobs:
         shell: bash
         run: |
           set +e
-          npm audit --omit=dev --audit-level=high 2>&1 | tee audit.txt
-          audit_status=${PIPESTATUS[0]}
+          npm audit --omit=dev --audit-level=high --json > audit.json 2> audit.stderr
+          audit_status=$?
           set -e
-          if [ "$audit_status" -ne 0 ]; then
-            echo "::warning::npm audit reported advisories; see the audit artifact and the dependency-maintenance ticket."
+          if [ "$audit_status" -eq 0 ]; then
+            echo "npm audit completed without high-severity advisories."
+            exit 0
           fi
+
+          node --input-type=commonjs <<'NODE'
+          const fs = require('node:fs');
+
+          let report;
+          try {
+            report = JSON.parse(fs.readFileSync('audit.json', 'utf8'));
+          } catch (error) {
+            console.error(`::error::npm audit did not produce valid JSON: ${error.message}`);
+            process.exit(1);
+          }
+
+          if (report?.metadata?.vulnerabilities) {
+            const { info = 0, low = 0, moderate = 0, high = 0, critical = 0, total = 0 } =
+              report.metadata.vulnerabilities;
+            console.warn(
+              `::warning::npm audit reported ${total} advisories (info=${info}, low=${low}, moderate=${moderate}, high=${high}, critical=${critical}); see the audit artifact and dependency-maintenance ticket.`,
+            );
+            process.exit(0);
+          }
+
+          console.error(
+            '::error::npm audit failed operationally; the dependency smoke gate must not pass without an audit report.',
+          );
+          process.exit(1);
+          NODE
 
       - name: Upload dependency evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: dependency-audit
-          path: audit.txt
+          path: |
+            audit.json
+            audit.stderr
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,105 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install locked dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Lint backend
+        run: npm run lint --workspace backend -- --no-fix
+
+      - name: Reject disabled lint/type checks
+        run: npm run lint:check-disables --workspace backend
+
+      - name: Build backend
+        run: npm run build --workspace backend
+
+      - name: Test backend
+        run: npm test --workspace backend -- --runInBand
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install locked dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Lint frontend
+        run: npm run lint --workspace frontend
+
+      - name: Build frontend
+        run: npm run build --workspace frontend
+
+  dependency-smoke:
+    name: Dependency smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Verify locked install
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Verify top-level dependency graph
+        run: npm ls --all --depth=0
+
+      - name: Audit production dependency graph
+        shell: bash
+        run: |
+          set +e
+          npm audit --omit=dev --audit-level=high 2>&1 | tee audit.txt
+          audit_status=${PIPESTATUS[0]}
+          set -e
+          if [ "$audit_status" -ne 0 ]; then
+            echo "::warning::npm audit reported advisories; see the audit artifact and the dependency-maintenance ticket."
+          fi
+
+      - name: Upload dependency evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-audit
+          path: audit.txt
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Full-Stack Authentication Boilerplate
 
+[![CI](https://github.com/Mohammed-Abdelhady/nextjs-nestjs-oauth-rbac-boilerplate/actions/workflows/ci.yml/badge.svg)](https://github.com/Mohammed-Abdelhady/nextjs-nestjs-oauth-rbac-boilerplate/actions/workflows/ci.yml)
+
 Production-ready authentication system with **NestJS** backend and **Next.js** frontend.
 
 ## Features

--- a/backend/src/auth/services/oauth.service.spec.ts
+++ b/backend/src/auth/services/oauth.service.spec.ts
@@ -33,6 +33,8 @@ describe('OAuthService', () => {
     authProvider: AuthProvider.GOOGLE,
     isVerified: true,
     googleId: 'google-123',
+    linkedProviders: [AuthProvider.GOOGLE],
+    primaryProvider: AuthProvider.GOOGLE,
     save: jest.fn().mockResolvedValue(undefined),
   };
 
@@ -58,6 +60,7 @@ describe('OAuthService', () => {
     // Mock GoogleOAuthStrategy
     googleStrategy = {
       provider: 'google',
+      isEnabled: true,
       getAuthorizationUrl: jest.fn(),
       getUserProfile: jest.fn(),
     } as unknown as jest.Mocked<GoogleOAuthStrategy>;
@@ -65,6 +68,7 @@ describe('OAuthService', () => {
     // Mock GitHubOAuthStrategy
     githubStrategy = {
       provider: 'github',
+      isEnabled: true,
       getAuthorizationUrl: jest.fn(),
       getUserProfile: jest.fn(),
     } as unknown as jest.Mocked<GitHubOAuthStrategy>;
@@ -72,6 +76,7 @@ describe('OAuthService', () => {
     // Mock FacebookOAuthStrategy
     facebookStrategy = {
       provider: 'facebook',
+      isEnabled: true,
       getAuthorizationUrl: jest.fn(),
       getUserProfile: jest.fn(),
     } as unknown as jest.Mocked<FacebookOAuthStrategy>;
@@ -209,6 +214,8 @@ describe('OAuthService', () => {
         ...mockUser,
         googleId: undefined,
         authProvider: AuthProvider.EMAIL,
+        linkedProviders: [],
+        primaryProvider: AuthProvider.EMAIL,
         save: jest.fn().mockResolvedValue(undefined),
       };
       userModel.findOne
@@ -249,6 +256,8 @@ describe('OAuthService', () => {
         isVerified: true,
         authProvider: AuthProvider.GOOGLE,
         role: 'user',
+        linkedProviders: [AuthProvider.GOOGLE],
+        primaryProvider: AuthProvider.GOOGLE,
       });
     });
 
@@ -290,6 +299,8 @@ describe('OAuthService', () => {
       authProvider: AuthProvider.GITHUB,
       isVerified: true,
       githubId: 'github-456',
+      linkedProviders: [AuthProvider.GITHUB],
+      primaryProvider: AuthProvider.GITHUB,
       save: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -337,6 +348,8 @@ describe('OAuthService', () => {
         isVerified: true,
         authProvider: AuthProvider.GITHUB,
         role: 'user',
+        linkedProviders: [AuthProvider.GITHUB],
+        primaryProvider: AuthProvider.GITHUB,
       });
     });
 
@@ -345,6 +358,8 @@ describe('OAuthService', () => {
         ...mockGitHubUser,
         githubId: undefined,
         authProvider: AuthProvider.EMAIL,
+        linkedProviders: [],
+        primaryProvider: AuthProvider.EMAIL,
         save: jest.fn().mockResolvedValue(undefined),
       };
       userModel.findOne
@@ -375,6 +390,8 @@ describe('OAuthService', () => {
       authProvider: AuthProvider.FACEBOOK,
       isVerified: true,
       facebookId: 'facebook-789',
+      linkedProviders: [AuthProvider.FACEBOOK],
+      primaryProvider: AuthProvider.FACEBOOK,
       save: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -426,6 +443,8 @@ describe('OAuthService', () => {
         isVerified: true,
         authProvider: AuthProvider.FACEBOOK,
         role: 'user',
+        linkedProviders: [AuthProvider.FACEBOOK],
+        primaryProvider: AuthProvider.FACEBOOK,
       });
     });
 
@@ -434,6 +453,8 @@ describe('OAuthService', () => {
         ...mockFacebookUser,
         facebookId: undefined,
         authProvider: AuthProvider.EMAIL,
+        linkedProviders: [],
+        primaryProvider: AuthProvider.EMAIL,
         save: jest.fn().mockResolvedValue(undefined),
       };
       userModel.findOne

--- a/backend/src/auth/strategies/facebook-oauth.strategy.spec.ts
+++ b/backend/src/auth/strategies/facebook-oauth.strategy.spec.ts
@@ -6,7 +6,8 @@ describe('FacebookOAuthStrategy', () => {
   let strategy: FacebookOAuthStrategy;
   let configService: jest.Mocked<ConfigService>;
 
-  const mockConfig: Record<string, string> = {
+  const mockConfig: Record<string, string | boolean> = {
+    'oauth.facebook.enabled': true,
     'oauth.facebook.clientId': 'test-app-id',
     'oauth.facebook.clientSecret': 'test-app-secret',
     'oauth.facebook.callbackUrl':

--- a/backend/src/auth/strategies/github-oauth.strategy.spec.ts
+++ b/backend/src/auth/strategies/github-oauth.strategy.spec.ts
@@ -6,7 +6,8 @@ describe('GitHubOAuthStrategy', () => {
   let strategy: GitHubOAuthStrategy;
   let configService: jest.Mocked<ConfigService>;
 
-  const mockConfig: Record<string, string> = {
+  const mockConfig: Record<string, string | boolean> = {
+    'oauth.github.enabled': true,
     'oauth.github.clientId': 'test-client-id',
     'oauth.github.clientSecret': 'test-client-secret',
     'oauth.github.callbackUrl':

--- a/backend/src/auth/strategies/google-oauth.strategy.spec.ts
+++ b/backend/src/auth/strategies/google-oauth.strategy.spec.ts
@@ -6,7 +6,8 @@ describe('GoogleOAuthStrategy', () => {
   let strategy: GoogleOAuthStrategy;
   let configService: jest.Mocked<ConfigService>;
 
-  const mockConfig: Record<string, string> = {
+  const mockConfig: Record<string, string | boolean> = {
+    'oauth.google.enabled': true,
     'oauth.google.clientId': 'test-client-id',
     'oauth.google.clientSecret': 'test-client-secret',
     'oauth.google.callbackUrl':

--- a/backend/src/common/dto/api-response.dto.ts
+++ b/backend/src/common/dto/api-response.dto.ts
@@ -49,19 +49,19 @@ export class ErrorDetails {
     example: 'INVALID_CREDENTIALS',
     enum: Object.values(ErrorCode),
   })
-  code: ErrorCode;
+  code!: ErrorCode;
 
   @ApiProperty({
     description: 'Human-readable error message',
     example: 'Invalid email or password',
   })
-  message: string;
+  message!: string;
 
   @ApiProperty({
     description: 'Optional additional context (e.g., field errors, retry info)',
     example: { remainingAttempts: 3 },
     required: false,
-    type: 'object',
+    type: Object,
     additionalProperties: true,
   })
   details?: Record<string, unknown>;

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -4,6 +4,7 @@ import { Types } from 'mongoose';
 import * as bcrypt from 'bcrypt';
 import { UserService } from './user.service';
 import { User } from './schemas/user.schema';
+import { Role } from '../role/schemas/role.schema';
 import { UserRole } from './enums/user-role.enum';
 import { SessionService } from '../auth/services/session.service';
 import { AppException } from '../common/exceptions/app.exception';
@@ -47,6 +48,12 @@ describe('UserService', () => {
     findById: jest.fn(),
   };
 
+  const mockRoleModel = {
+    findOne: jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue(null),
+    }),
+  };
+
   const mockSessionService = {
     getUserSessions: jest.fn().mockResolvedValue([mockSession]),
     getSessionByToken: jest.fn().mockResolvedValue(mockSession),
@@ -63,6 +70,10 @@ describe('UserService', () => {
         {
           provide: getModelToken(User.name),
           useValue: mockUserModel,
+        },
+        {
+          provide: getModelToken(Role.name),
+          useValue: mockRoleModel,
         },
         {
           provide: SessionService,

--- a/docs/code-quality.md
+++ b/docs/code-quality.md
@@ -22,7 +22,8 @@ stable checks:
 - **Backend** — locked install, backend lint, forbidden-disable scan, build, and Jest tests.
 - **Frontend** — locked install, ESLint, and the production Next.js build.
 - **Dependency smoke** — locked-install verification, top-level dependency graph output,
-  and a production dependency audit uploaded as an artifact.
+  and a production dependency audit uploaded as an artifact. Known vulnerability
+  advisories remain non-blocking, but registry/network/CLI failures fail the check.
 
 The audit step is intentionally non-blocking while the existing advisory baseline is
 handled by the dependency-maintenance workstream. Advisories are still printed as a
@@ -39,7 +40,9 @@ npm test --workspace backend -- --runInBand
 npm run lint --workspace frontend
 npm run build --workspace frontend
 npm ls --all --depth=0
-npm audit --omit=dev --audit-level=high
+npm audit --omit=dev --audit-level=high --json > audit.json 2> audit.stderr
+# A non-zero exit is acceptable only when audit.json contains metadata.vulnerabilities.
+# Missing/invalid audit metadata indicates an operational failure and must fail CI.
 ```
 
 ## Pre-commit Hooks

--- a/docs/code-quality.md
+++ b/docs/code-quality.md
@@ -13,6 +13,35 @@ This project uses a comprehensive code quality automation system to ensure consi
 - **Commit message linting** (commitlint) - Enforce Conventional Commits format
 - **Test automation** - Run relevant tests before committing
 
+## GitHub Actions CI
+
+The [CI workflow](../.github/workflows/ci.yml) runs on pull requests and pushes to
+`master`. It uses Node.js 20 and the committed `package-lock.json` to expose three
+stable checks:
+
+- **Backend** — locked install, backend lint, forbidden-disable scan, build, and Jest tests.
+- **Frontend** — locked install, ESLint, and the production Next.js build.
+- **Dependency smoke** — locked-install verification, top-level dependency graph output,
+  and a production dependency audit uploaded as an artifact.
+
+The audit step is intentionally non-blocking while the existing advisory baseline is
+handled by the dependency-maintenance workstream. Advisories are still printed as a
+warning and retained in the workflow artifact; they are not hidden or auto-fixed by CI.
+
+Run the same checks locally:
+
+```bash
+npm ci --ignore-scripts --no-audit --no-fund
+npm run lint --workspace backend -- --no-fix
+npm run lint:check-disables --workspace backend
+npm run build --workspace backend
+npm test --workspace backend -- --runInBand
+npm run lint --workspace frontend
+npm run build --workspace frontend
+npm ls --all --depth=0
+npm audit --omit=dev --audit-level=high
+```
+
 ## Pre-commit Hooks
 
 ### What They Do

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.562.0",
-        "next": "^16.2.3",
+        "next": "16.2.3",
         "next-intl": "^4.7.0",
         "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
@@ -2389,6 +2389,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2411,6 +2412,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2433,6 +2435,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2449,6 +2452,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2465,6 +2469,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2481,6 +2486,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2497,6 +2503,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2513,6 +2520,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2529,6 +2537,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2545,6 +2554,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2561,6 +2571,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2577,6 +2588,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2593,6 +2605,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2615,6 +2628,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2637,6 +2651,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2659,6 +2674,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2681,6 +2697,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2703,6 +2720,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2725,6 +2743,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2747,6 +2766,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2766,6 +2786,7 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -2788,6 +2809,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2807,6 +2829,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2826,6 +2849,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -16475,6 +16499,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -17339,6 +17374,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }


### PR DESCRIPTION
## Summary
- Add Node 20 checks for the backend, frontend, and dependency graph.
- Fix DTO compile errors and update OAuth test fixtures so the existing backend suite can run in CI.
- Document the local CI commands and add the workflow badge to the README.

## Test plan
- [x] `npm ci --ignore-scripts --no-audit --no-fund`
- [x] Backend lint, disable scan, build, and 124 Jest tests
- [x] Frontend lint and production build
- [x] `npm ls --all --depth=0`
- [x] GitHub Actions: Backend, Frontend, and Dependency smoke
- [ ] `npm audit --omit=dev --audit-level=high` is clean. The workflow records the existing advisory baseline as a non-blocking warning.

## Risk / rollback
- The workflow adds required CI time but does not change deployment behavior.
- Dependency advisories remain visible but do not fail this first CI pass.
- Revert commit `899ae9e` to remove these checks and fixture updates.
