### PR TITLE
fix: update nanoid to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16120,9 +16120,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Update the transitive `nanoid` lockfile resolution from 3.3.11 to 3.3.18.
- Resolve CVE-2026-67213 and CVE-2026-67214 without changing package manifests or unrelated dependencies.

## Test plan
- [x] `npm audit --package-lock-only --omit=dev --json` no longer reports `nanoid`.
- [x] `npm ls nanoid --all` resolves 3.3.18 through both postcss paths.
- [x] Backend lint passes.
- [x] Frontend lint and typecheck pass.
- [x] Frontend production build passes.

## Existing baseline failures
- `npm ci` also fails on untouched `master` because the committed lockfile is missing `@swc/helpers@0.5.23`.
- Root lint has no root ESLint 9 flat config.
- Backend typecheck and build remain red on three existing DTO errors. Backend tests also include existing DTO and unconfigured OAuth failures.

## Risk and rollback
- Risk is low. This changes one transitive lockfile node, and both parent postcss ranges already accept 3.3.18.
- Revert the commit to restore the previous resolution.
